### PR TITLE
Update Readme for 0.91 change to Dark Sky Sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ To place your card in your display, here's the configuration:
   image: https://bit.ly/2FNnlTT
   title: Current ORD Forecast
   forecast: sensor.dark_sky_daily_summary
-  high: sensor.dark_sky_daytime_high_temperature_0       <-------
-  low: sensor.dark_sky_overnight_low_temperature_0       <-------
+  high: sensor.dark_sky_daytime_high_temperature_0d       <-------
+  low: sensor.dark_sky_overnight_low_temperature_0d       <-------
   summary: sensor.dark_sky_summary
   units: F
 ~~~~
@@ -70,6 +70,10 @@ Note that we're assuming you've already got all the required Dark Sky sensors im
 
 `title` is a freeform field - put in anything you like.
 `units` is a dumb field - put in `F` or `C` or whatever you like. It's just text.
+
+Reload your display and you should have an animated radar card. 
+
+**Version 0.91.0 change** The high and low temperatures now need **`_0d`** added to the end of their definition. If you don't change or include this, the card is going to fail and blank out your page. This is similar to the change required in 0.83.1.
 
 Reload your display and you should have an animated radar card. 
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is the trickiest part. It's not hard, just requires a few steps.
    * Try pasting it into an empty browser tab to test.
 7. Once you're sure it's right and it works, I suggest running it through [Bitly](https://bitly.com) to shorten it to something reasonable.
    * https://radblast.wunderground.com/cgi-bin/radar/WUNIDS_map?station=MDW&brand=wui&num=1&delay=15&type=TR0&frame=0&scale=0.75&noclutter=0&showstorms=0&mapx=400&mapy=240&centerx=400&centery=240&transx=0&transy=0&showlabels=1&severe=0&rainsnow=1&lightning=0&smooth=0&rand=25725764&lat=0&lon=0&label=you
-   * becomes
+   * becomess
    * https://bit.ly/2QtHrqm
  8. This is your image URL. Don't lose it or you'll have to start over.
  


### PR DESCRIPTION
Due to HomeAssistant PR [#21820](https://github.com/home-assistant/home-assistant/pull/21820) the Dark Sky sensor now needs "_0d" appended to the end of it, not just "_0".

Updated the docs to reflect this.